### PR TITLE
Enable registering additional helper functions in ExpressionsSupport

### DIFF
--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionsSupportSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/expressions/ExpressionsSupportSpec.groovy
@@ -166,6 +166,23 @@ class ExpressionsSupportSpec extends Specification {
     then:
     context.variables.containsKey("test_hello")
   }
+
+  def "support registering helper function"() {
+    given:
+    ExpressionsSupport.addHelperFunction("woop", CustomHelperFunction.class, Collections.singletonList(String.class))
+
+    when:
+    EvaluationContext context = ExpressionsSupport.newEvaluationContext(pipeline, false)
+
+    then:
+    context.variables.containsKey("woop")
+  }
+}
+
+class CustomHelperFunction {
+  static String woop(String other) {
+    return "Woop $other"
+  }
 }
 
 class HelloExpressionFunctionProvider implements ExpressionFunctionProvider {


### PR DESCRIPTION
This will enable us to register custom helper functions that can run even when `allowUnknownKeys=false` (which is what happens when a pipeline is evaluated in the `/orchestrate` endpoint in Orca.

This change will become obsolete once we can update Orca as `ExpressionsSupport` is moved to `kork`, and the way that custom expressions are registered is changed.